### PR TITLE
Deprecate repository in favour of main Arduino repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Arduino Shield HAT for Raspberry Pi
+
+> [!WARNING]
+> This repository has been overtaken by [fufarm_arduino_sensors](https://github.com/farm-urban/fufarm_arduino_sensors) as of <https://github.com/farm-urban/fufarm_arduino_sensors/pulls/8>. Any new works or maintenance will happen there.
+
 Code for managing the [Gravity: Arduino Shield HAT for Raspberry Pi](https://thepihut.com/products/arduino-shield-for-raspberry-pi-b-2b-3b)
 
 This handles compiling and uploading the code for the Arduino shield on the Raspberry Pi to create a usb serial console that can be read to get the sensor values


### PR DESCRIPTION
With https://github.com/farm-urban/fufarm_arduino_sensors/pull/8, the code for sensors using Arduino can now be placed in one repository. This allows us to archive this repo after merging this PR.
